### PR TITLE
use correct variable template, use scala 2.12

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 # file: scala/defaults/main.yml
 
-scala_versions: ["2.10.3"]              # A list of scala versions you want to have installed
-scala_default_version: "2.10.3"         # The scala version you want to be the system default
-scala_sbt_version: "0.13.1"             # The version of sbt to install
+scala_versions: ["2.12.1"]              # A list of scala versions you want to have installed
+scala_default_version: "2.12.1"         # The scala version you want to be the system default
+scala_sbt_version: "0.13.13"            # The version of sbt to install

--- a/tasks/binaries.yml
+++ b/tasks/binaries.yml
@@ -4,7 +4,7 @@
   get_url:
     url: "http://www.scala-lang.org/files/archive/scala-{{item}}.tgz"
     dest: "/tmp/scala-{{item}}.tgz"
-  with_items: scala_versions
+  with_items: "{{scala_versions}}"
 
 - name: Scala | Make sure the directory to hold the Scala binaries is present
   file:
@@ -13,7 +13,7 @@
 
 - name: Scala | Unpack the compressed Scala binaries
   command: tar -xvzf /tmp/scala-{{item}}.tgz chdir=/usr/local/scala creates=/usr/local/scala/scala-{{item}}
-  with_items: scala_versions
+  with_items: "{{scala_versions}}"
 
 - name: Scala | Set the permissions on the Scala binaries
   file:
@@ -21,7 +21,7 @@
     state: directory
     mode: 0755
     recurse: yes
-  with_items: scala_versions
+  with_items: "{{scala_versions}}"
 
 - name: Scala | Update the symbolic link to the default Scala version
   file:


### PR DESCRIPTION
Hi,

I was running this script on Ubuntu 16.04 on Vagrant, and it was failing because it was trying to look for 'http://www.scala-lang.org/files/archive/scala-scala_versions.tgz' to download, and the variable scala_versions was not being correctly replaced to the version number.